### PR TITLE
adds support for the spacestation13.github.io/byond-builds mirror

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,6 +5,10 @@ use clap::{Parser, Subcommand};
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 pub(super) struct Cli {
+	/// Use spacestation13.github.io/byond-builds instead of byond.com.
+	#[arg(global = true, long, short)]
+	pub(super) mirror: bool,
+
 	#[command(flatten)]
 	pub(super) verbose: clap_verbosity_flag::Verbosity,
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -6,11 +6,17 @@ use url::Url;
 use crate::{byondversion::ByondVersion, errors, pagerdata};
 
 const BYOND_DOWNLOAD_BASEURL: &str = "https://www.byond.com/download/build/";
+const BYOND_DOWNLOAD_BASEURL_MIRROR: &str = "https://spacestation13.github.io/byond-builds/";
 const BYOND_DOWNLOAD_FILENAME_SUFFIX_WINDOWS: &str = "_byond.zip";
 const BYOND_DOWNLOAD_FILENAME_SUFFIX_LINUX: &str = "_byond_linux.zip";
 
 pub fn construct_download_url(byond_version: &ByondVersion) -> Result<Url> {
-	let url = Url::parse(BYOND_DOWNLOAD_BASEURL)?
+	let base_url = if crate::should_use_mirror() {
+		BYOND_DOWNLOAD_BASEURL_MIRROR
+	} else {
+		BYOND_DOWNLOAD_BASEURL
+	};
+	let url = Url::parse(base_url)?
 		.join(format!("{}/", byond_version.major).as_str())?
 		.join(format!("{}{}", byond_version, downloadurl_platform_suffix()?).as_str())?;
 	Ok(url)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,16 @@ pub mod manifest;
 pub mod pagerdata;
 pub mod paths;
 pub mod versionfile;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+// yeah yeah yeah it's a global flag, idc, bite me, i don't feel like forwarding a single arg through so many layers.
+static USE_MIRROR: AtomicBool = AtomicBool::new(false);
+
+pub fn set_mirror(should_use_mirror: bool) {
+	USE_MIRROR.store(should_use_mirror, Ordering::Relaxed);
+}
+
+pub fn should_use_mirror() -> bool {
+	USE_MIRROR.load(Ordering::Relaxed)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,10 @@ fn run() -> Result<()> {
 		.env()
 		.init()?;
 
+	if cli.mirror {
+		melatonin::set_mirror(true);
+	}
+
 	match cli.command {
 		Commands::Fetch { beta } => fetch::fetch(beta),
 		Commands::Install { version } => install::install(version),

--- a/src/pagerdata/hub.rs
+++ b/src/pagerdata/hub.rs
@@ -1,14 +1,14 @@
 use anyhow::{anyhow, Result};
 use regex::Regex;
 
+use super::REQUEST_TIMEOUT;
 use crate::byondversion::ByondVersion;
 
 const BYOND_PAGER_URL: &str = "https://www.byond.com/PagerHome";
-const REQUEST_TIMEOUT: u64 = 10;
 const REGEXP_LATEST_VERSION: &str = r#"latest_version:\s+["'](?P<version>\d+)\.(?P<build>\d+)["'],?"#;
 const REGEXP_BETA_VERSION: &str = r#"beta_version:\s+["'](?P<version>\d+)\.(?P<build>\d+)["'],?"#;
 
-pub fn latest_version(beta: bool) -> Result<ByondVersion> {
+pub(super) fn latest_version(beta: bool) -> Result<ByondVersion> {
 	log::debug!(
 		"Attempting to fetch latest {} version of BYOND...",
 		if beta { "beta" } else { "stable" }

--- a/src/pagerdata/mirror.rs
+++ b/src/pagerdata/mirror.rs
@@ -1,0 +1,17 @@
+use anyhow::{anyhow, Context, Result};
+use std::str::FromStr;
+
+use super::REQUEST_TIMEOUT;
+use crate::byondversion::ByondVersion;
+
+const MIRROR_VERSION_URL: &str = "https://spacestation13.github.io/byond-builds/version.txt";
+
+pub(super) fn latest_version(beta: bool) -> Result<ByondVersion> {
+	log::debug!("Fetching version data from {MIRROR_VERSION_URL}");
+	let version_txt = minreq::get(MIRROR_VERSION_URL).with_timeout(REQUEST_TIMEOUT).send()?;
+	let mut version_txt = version_txt.as_str()?.trim().lines();
+	version_txt
+		.nth(if beta { 1 } else { 0 })
+		.ok_or(anyhow!("Could not find desired version in version.txt"))
+		.and_then(|version| ByondVersion::from_str(version).context("Failed to parse BYOND version"))
+}

--- a/src/pagerdata/mod.rs
+++ b/src/pagerdata/mod.rs
@@ -1,0 +1,15 @@
+pub mod hub;
+pub mod mirror;
+
+use crate::byondversion::ByondVersion;
+use anyhow::Result;
+
+const REQUEST_TIMEOUT: u64 = 10;
+
+pub fn latest_version(beta: bool) -> Result<ByondVersion> {
+	if crate::should_use_mirror() {
+		mirror::latest_version(beta)
+	} else {
+		hub::latest_version(beta)
+	}
+}


### PR DESCRIPTION
This adds support for the BYOND builds mirror at https://spacestation13.github.io/byond-builds, so that this still works during the ongoing BYOND DDoS.

The mirror is used by passing `--mirror` or `-m` to bvm.

![2025-07-04 (1751676798) ~ Code](https://github.com/user-attachments/assets/162a274e-b47d-4bb3-a17d-c7448ca160de)